### PR TITLE
Add missing buildtool_depend on git

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
   <license>MIT</license>  <!-- sol2 is MIT -->
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>git</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ouxt_lint_common</test_depend>


### PR DESCRIPTION
This package uses git to download the sol sources during build. It should declare a dependency on git.

This should address one of the issues failing the RPM builds on the ROS 2 buildfarm: https://build.ros2.org/view/Rbin_rhel_el864/job/Rbin_rhel_el864__sol_vendor__rhel_8_x86_64__binary/